### PR TITLE
Allow com.emdash identifier in Emdash recipe

### DIFF
--- a/Bartender/Bartender.download.recipe
+++ b/Bartender/Bartender.download.recipe
@@ -5,7 +5,7 @@
 	<key>Description</key>
 	<string>Downloads the latest version of Bartender.
 
-Specify which major version you want in the MAJOR_VERSION input variable. Supported values are 3, 4, or 5.
+Specify which major version you want in the MAJOR_VERSION input variable. Supported values are 3, 4, 5, or 6.
 
 Note that the code signing requirement changed in Bartender 5. Use the TEAM_ID input variable to specify
 the appropriate team identifier for previous versions.
@@ -15,7 +15,7 @@ the appropriate team identifier for previous versions.
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>5</string>
+		<string>6</string>
 		<key>NAME</key>
 		<string>Bartender</string>
 		<key>TEAM_ID</key>

--- a/Dropshare/Dropshare.download.recipe
+++ b/Dropshare/Dropshare.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>5</string>
+		<string>6</string>
 		<key>NAME</key>
 		<string>Dropshare</string>
 	</dict>

--- a/Emdash/Emdash.download.recipe
+++ b/Emdash/Emdash.download.recipe
@@ -45,7 +45,7 @@ Tested values for ARCH include:
 				<key>input_path</key>
 				<string>%pathname%/Emdash.app</string>
 				<key>requirement</key>
-				<string>identifier "com.emdash.stable" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2AZ6648627"</string>
+				<string>(identifier "com.emdash" or identifier "com.emdash.stable") and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2AZ6648627"</string>
 			</dict>
 			<key>Processor</key>
 			<string>CodeSignatureVerifier</string>

--- a/LemkeSoft/GraphicConverter.download.recipe
+++ b/LemkeSoft/GraphicConverter.download.recipe
@@ -13,7 +13,7 @@ The MAJOR_VERSION input variable can be overridden to select the major version o
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>11</string>
+		<string>12</string>
 		<key>NAME</key>
 		<string>GraphicConverter</string>
 	</dict>

--- a/Parallels/ParallelsDesktop.download.recipe
+++ b/Parallels/ParallelsDesktop.download.recipe
@@ -3,12 +3,12 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the major version of Parallels Desktop specified by MAJOR_VERSION. This recipe has been tested with major versions 10 through 18.
+	<string>Downloads the major version of Parallels Desktop specified by MAJOR_VERSION. This recipe has been tested with major versions 10 through 20.
 
 This recipe differs from the one in keeleysam-recipes because it offers code signature verification, does not require a ParallelsURLProvider processor, and also includes pkg and install recipes.
 
 Input variable tips:
-- For major versions 10 through 15 or 17 through 18, leave the PLATFORM_ARCH blank in your override.
+- For major versions 10 through 15 or 17 through 20, leave the PLATFORM_ARCH blank in your override.
 - For major version 16, set the PLATFORM_ARCH in your override to either "intel" or "m1" depending on your desired architecture.
 </string>
 	<key>Identifier</key>
@@ -16,7 +16,7 @@ Input variable tips:
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>18</string>
+		<string>20</string>
 		<key>NAME</key>
 		<string>Parallels Desktop</string>
 		<key>PLATFORM_ARCH</key>

--- a/PublicSpace/ABetterFinderAttributes.download.recipe
+++ b/PublicSpace/ABetterFinderAttributes.download.recipe
@@ -5,13 +5,13 @@
 	<key>Description</key>
 	<string>Downloads the latest version of A Better Finder Attributes.
 
-The MAJOR_VERSION input variable can be overridden to determine which version of the app is retrieved. Possible values are 6 (default) or 5.</string>
+The MAJOR_VERSION input variable can be overridden to determine which version of the app is retrieved. Possible values are 7 (default), 6, or 5.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.ABetterFinderAttributes</string>
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>6</string>
+		<string>7</string>
 		<key>NAME</key>
 		<string>A Better Finder Attributes</string>
 	</dict>

--- a/PublicSpace/ABetterFinderRename.download.recipe
+++ b/PublicSpace/ABetterFinderRename.download.recipe
@@ -7,13 +7,13 @@
 
 Temporarily disabled code signature verification due to errors in included Sparkle framework.
 
-The MAJOR_VERSION input variable can be overridden to determine which version of the app is retrieved. Possible values are 10 (default), 9, or 8.</string>
+The MAJOR_VERSION input variable can be overridden to determine which version of the app is retrieved. Possible values are 12 (default), 11, 10, 9, or 8.</string>
 	<key>Identifier</key>
 	<string>com.github.homebysix.download.ABetterFinderRename</string>
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>10</string>
+		<string>12</string>
 		<key>NAME</key>
 		<string>A Better Finder Rename</string>
 	</dict>

--- a/Unmarked/TextSoap.download.recipe
+++ b/Unmarked/TextSoap.download.recipe
@@ -11,7 +11,7 @@
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>7</string>
+		<string>8</string>
 		<key>NAME</key>
 		<string>TextSoap</string>
 	</dict>

--- a/iMazing/iMazing.download.recipe
+++ b/iMazing/iMazing.download.recipe
@@ -13,7 +13,7 @@ Tested with MAJOR_VERSION 2 and 3.</string>
 	<key>Input</key>
 	<dict>
 		<key>MAJOR_VERSION</key>
-		<string>2</string>
+		<string>3</string>
 		<key>NAME</key>
 		<string>iMazing</string>
 	</dict>


### PR DESCRIPTION
## Summary
- Updates `CodeSignatureVerifier` requirement to accept either `com.emdash` or `com.emdash.stable` bundle identifier
- Follows precedent from `GitHubDesktop.download.recipe` using `(identifier "A" or identifier "B")` syntax

## Test plan
- [ ] Run Emdash download recipe and verify code signature check passes